### PR TITLE
Added support for returning query builder results from get()

### DIFF
--- a/src/BaseQuery.php
+++ b/src/BaseQuery.php
@@ -3,7 +3,8 @@
 namespace Xabou\Query;
 
 
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 abstract class BaseQuery
 {
@@ -46,7 +47,7 @@ abstract class BaseQuery
     public static function get()
     {
         $builder = call_user_func_array([new static, 'body'], func_get_args());
-        if ($builder instanceof Builder) {
+        if ($builder instanceof EloquentBuilder || $builder instanceof QueryBuilder) {
             return $builder->get();
         }
 


### PR DESCRIPTION
I noticed that if I used the DB facade inside the body() method of a Query subclass that calling get() didn't return results. Instead it returned a Builder object.

This was because it only returned results for Eloquent query builder objects and didn't check for regular query builder objects.

This pull request just adds a check for the other type of query builder.